### PR TITLE
Ray session reusage, object cache stability improvement

### DIFF
--- a/kts/core/backend/address_manager.py
+++ b/kts/core/backend/address_manager.py
@@ -1,6 +1,8 @@
+import os
 import time
 
 import ray
+
 try:
     from ray.experimental import get_actor  # ray<=0.8.1
 except ImportError:
@@ -45,9 +47,11 @@ class AddressManager:
     def delete(self, key):
         self.is_none[key] = True
 
-def get_address_manager():
-    return get_actor('AddressManager')
 
+pid = os.getpid()
+
+def get_address_manager():
+    return get_actor(f"AddressManager{pid}")
 
 def create_address_manager():
-    return AddressManager.options(name="AddressManager").remote()
+    return AddressManager.options(name=f"AddressManager{pid}").remote()

--- a/kts/core/backend/run_manager.py
+++ b/kts/core/backend/run_manager.py
@@ -146,6 +146,7 @@ class RunManager:
             frame.__meta__['fold'] = fold
             frame.__meta__['run_manager'] = self
             frame.__meta__['report'] = report
+            frame.__meta__['pid'] = os.getpid()
             run_id = RunID(feature_constructor.name, frame._fold, frame.hash())
             with pbar.local_mode(report, run_id):
                 results[feature_constructor.name] = feature_constructor(frame, ret=ret)

--- a/kts/core/backend/signal.py
+++ b/kts/core/backend/signal.py
@@ -1,3 +1,4 @@
+import os
 from collections import defaultdict
 from typing import Union, Tuple, List, Any
 
@@ -39,11 +40,13 @@ class SignalManager:
         self.data.clear()
 
 
+pid = os.getpid()
+
 def get_signal_manager():
-    return get_actor('SignalManager')
+    return get_actor(f"SignalManager{pid}")
 
 def create_signal_manager():
-    return SignalManager.options(name="SignalManager").remote()
+    return SignalManager.options(name=f"SignalManager{pid}").remote()
 
 
 def send(signal):

--- a/kts/core/backend/worker.py
+++ b/kts/core/backend/worker.py
@@ -6,6 +6,7 @@ import pandas as pd
 import ray
 
 import kts.core.backend.signal as rs
+from kts.core.backend import signal, address_manager
 from kts.core.backend.progress import ProgressSignal
 from kts.core.backend.signal import RunPID
 from kts.core.backend.stats import Stats
@@ -16,6 +17,9 @@ from kts.core.frame import KTSFrame
 def worker(self, *args, df: pd.DataFrame, meta: Dict):
     assert 'run_manager' not in meta
     assert 'report' not in meta
+    assert 'pid' in meta
+    signal.pid = meta['pid']
+    address_manager.pid = meta['pid']
     kf = KTSFrame(df, meta=meta)
     kf.__meta__['remote'] = True
     return_state = kf._train

--- a/kts/core/frame.py
+++ b/kts/core/frame.py
@@ -96,7 +96,8 @@ class KTSFrame(pd.DataFrame):
             'fold': '0000',
             'scope': '__global__',
             'train': False,
-            'remote': False
+            'remote': False,
+            'pid': 0,
         }
     
 

--- a/kts/util/formatting.py
+++ b/kts/util/formatting.py
@@ -18,7 +18,7 @@ def format_value(value, time=False):
             res.append(f"{hours}h")
         if minutes:
             res.append(f"{minutes}m")
-        if seconds:
+        if seconds and not hours:
             res.append(f"{seconds}s")
         if not res:
             res = ['0s']

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setuptools.setup(
         "scikit-learn",
         "matplotlib",
         "cloudpickle",
+        "dill",
         "feather-format",
         "click",
         "xxhash",


### PR DESCRIPTION
**Backend**: Store current ray session address in /tmp/kts.ray_session, connect to it instead of creating a new ray. Separate address and signal managers for different drivers by adding driver pid to each manager name. Keep this driver pid in sync with worker processes through KTSFrame metadata.

**Cache**: In object cache, on cloudpickle failure, use dill.

**UI**: don't show seconds if time interval > 1h